### PR TITLE
Runnable on IntelHD GPU

### DIFF
--- a/Project/src/Common/IGraphicsContext.h
+++ b/Project/src/Common/IGraphicsContext.h
@@ -39,6 +39,8 @@ public:
 	virtual ITexture2D* createTexture2D() = 0;
 
 	virtual void sync() = 0;
+
+	virtual bool supportsRayTracing() const = 0;
 	
 public:
 	static IGraphicsContext* create(IWindow* pWindow, API api);

--- a/Project/src/Core/Application.cpp
+++ b/Project/src/Core/Application.cpp
@@ -75,6 +75,7 @@ void Application::init()
 
 	//Create context
 	m_pContext = IGraphicsContext::create(m_pWindow, API::VULKAN);
+	m_EnableRayTracing = m_pContext->supportsRayTracing();
 	
 	//Setup Imgui
 	m_pImgui = m_pContext->createImgui();
@@ -418,8 +419,7 @@ void Application::renderUI(double dt)
 
 void Application::render(double dt)
 {
-	static bool enableRayTracing = true;
-	if (enableRayTracing)
+	if (m_EnableRayTracing)
 	{
 		m_pRenderer->beginRayTraceFrame(m_Camera);
 		m_pRenderer->traceRays();
@@ -429,9 +429,9 @@ void Application::render(double dt)
 	{
 		m_pRenderer->beginFrame(m_Camera);
 
-	g_Rotation = glm::rotate(g_Rotation, glm::radians(30.0f * float(dt)), glm::vec3(0.0f, 1.0f, 0.0f));
-	m_pRenderer->submitMesh(m_pMesh, g_Color, glm::mat4(1.0f) * g_Rotation);
-	m_pRenderer->drawImgui(m_pImgui);
+		g_Rotation = glm::rotate(g_Rotation, glm::radians(30.0f * float(dt)), glm::vec3(0.0f, 1.0f, 0.0f));
+		m_pRenderer->submitMesh(m_pMesh, g_Color, glm::mat4(1.0f) * g_Rotation);
+		m_pRenderer->drawImgui(m_pImgui);
 
 		m_pRenderer->endFrame();
 	}

--- a/Project/src/Core/Application.h
+++ b/Project/src/Core/Application.h
@@ -60,6 +60,7 @@ private:
 
 	bool m_IsRunning;
 	bool m_UpdateCamera;
+	bool m_EnableRayTracing;
 
 	static Application* s_pInstance;
 };

--- a/Project/src/Vulkan/BufferVK.cpp
+++ b/Project/src/Vulkan/BufferVK.cpp
@@ -41,7 +41,7 @@ bool BufferVK::init(const BufferParams& params)
 	bufferInfo.size		= params.SizeInBytes;
 	bufferInfo.usage	= params.Usage;
 
-	if (params.IsExclusive)
+	if (params.IsExclusive || !m_pDevice->hasUniqueQueueFamilyIndices())
 	{
 		bufferInfo.queueFamilyIndexCount = 0;
 		bufferInfo.pQueueFamilyIndices = nullptr;
@@ -56,7 +56,7 @@ bool BufferVK::init(const BufferParams& params)
 	}
 
 	VK_CHECK_RESULT_RETURN_FALSE(vkCreateBuffer(m_pDevice->getDevice(), &bufferInfo, nullptr, &m_Buffer), "Failed to create buffer");
-	
+
 	m_Params = params;
 	D_LOG("--- Buffer: Vulkan Buffer created successfully. SizeInBytes=%d", m_Params.SizeInBytes);
 

--- a/Project/src/Vulkan/DeviceVK.cpp
+++ b/Project/src/Vulkan/DeviceVK.cpp
@@ -96,6 +96,18 @@ void DeviceVK::wait()
 	}
 }
 
+bool DeviceVK::hasUniqueQueueFamilyIndices() const
+{
+	std::set<uint32_t> familyIndices = {
+		m_DeviceQueueFamilyIndices.computeFamily.value(),
+		m_DeviceQueueFamilyIndices.graphicsFamily.value(),
+		m_DeviceQueueFamilyIndices.presentFamily.value(),
+		m_DeviceQueueFamilyIndices.transferFamily.value()
+	};
+
+	return familyIndices.size() == 4;
+}
+
 bool DeviceVK::initPhysicalDevice(InstanceVK* pInstance)
 {
 	uint32_t deviceCount = 0;

--- a/Project/src/Vulkan/DeviceVK.h
+++ b/Project/src/Vulkan/DeviceVK.h
@@ -52,8 +52,10 @@ public:
 	CopyHandlerVK* getCopyHandler() const { return m_pCopyHandler; }
 
 	const QueueFamilyIndices& getQueueFamilyIndices() const { return m_DeviceQueueFamilyIndices; }
+	bool hasUniqueQueueFamilyIndices() const;
 	
 	const VkPhysicalDeviceRayTracingPropertiesNV& getRayTracingProperties() const { return m_RayTracingProperties; }
+	bool supportsRayTracing() const { return m_ExtensionsStatus.at(VK_NV_RAY_TRACING_EXTENSION_NAME); }
 
 private:
 	bool initPhysicalDevice(InstanceVK* pInstance);

--- a/Project/src/Vulkan/GraphicsContextVK.cpp
+++ b/Project/src/Vulkan/GraphicsContextVK.cpp
@@ -122,3 +122,8 @@ void GraphicsContextVK::swapBuffers(VkSemaphore renderSemaphore)
 {
 	m_pSwapChain->present(renderSemaphore);
 }
+
+bool GraphicsContextVK::supportsRayTracing() const
+{
+	m_Device.supportsRayTracing();
+}

--- a/Project/src/Vulkan/GraphicsContextVK.h
+++ b/Project/src/Vulkan/GraphicsContextVK.h
@@ -22,14 +22,14 @@ public:
 	//OVERRIDE
 	virtual IRenderer* createRenderer() override;
 	virtual IImgui* createImgui() override;
-    
+
     virtual IMesh* createMesh() override;
 
 	virtual IShader* createShader() override;
-	
+
 	virtual IBuffer* createBuffer() override;
 	virtual IFrameBuffer* createFrameBuffer() override;
-	
+
 	virtual IImage* createImage() override;
 	virtual IImageView* createImageView() override;
 	virtual ITexture2D* createTexture2D() override;
@@ -37,6 +37,8 @@ public:
 	virtual void sync() override;
 
 	void swapBuffers(VkSemaphore renderSemaphore);
+
+	bool supportsRayTracing() const;
 
 	DeviceVK* getDevice() { return &m_Device; } //Const function?
 	SwapChainVK* getSwapChain() const { return m_pSwapChain; }

--- a/Project/src/Vulkan/RendererVK.h
+++ b/Project/src/Vulkan/RendererVK.h
@@ -66,6 +66,7 @@ private:
 	bool createPipelines();
 	bool createPipelineLayouts();
 	bool createBuffers();
+	void initRayTracing();
 
 	bool createRayTracingPipelineLayouts();
 	


### PR DESCRIPTION
To make the master branch runnable on IntelHD GPUs, the following things had to be done:
* Make Ray-Tracing setup optional
* When choosing between a queue-CONCURRENT or queue-EXCLUSIVE buffer, check if the queue family indices are different from each other. On intelHD GPUs they aren't, which means EXCLUSIVE has to be picked.
* Set Ray Tracing resources in RendererVK to nullptr as the renderer is constructed, so that they aren't attempted to be deleted if they are never created to begin with.