### PR TITLE
Particle controls

### DIFF
--- a/Project/src/Common/IParticleEmitterHandler.h
+++ b/Project/src/Common/IParticleEmitterHandler.h
@@ -28,6 +28,7 @@ public:
     ParticleEmitter* createEmitter(const ParticleEmitterInfo& emitterInfo);
 
     std::vector<ParticleEmitter*>& getParticleEmitters() { return m_ParticleEmitters; }
+    ParticleEmitter* getParticleEmitter(size_t idx) { return m_ParticleEmitters[idx]; }
 
     bool gpuComputed() const { return m_GPUComputed; }
     virtual void toggleComputationDevice() = 0;

--- a/Project/src/Core/Application.cpp
+++ b/Project/src/Core/Application.cpp
@@ -49,7 +49,8 @@ Application::Application()
 	m_IsRunning(false),
 	m_UpdateCamera(false),
 	m_pParticleTexture(nullptr),
-	m_pParticleEmitterHandler(nullptr)
+	m_pParticleEmitterHandler(nullptr),
+	m_CurrentEmitterIdx(0)
 {
 	ASSERT(s_pInstance == nullptr);
 	s_pInstance = this;
@@ -468,7 +469,7 @@ void Application::renderUI(double dt)
 	ImGui::End();
 
 	// Particle control panel
-	ImGui::SetNextWindowSize(ImVec2(280, 110), ImGuiCond_Always);
+	ImGui::SetNextWindowSize(ImVec2(320, 210), ImGuiCond_Always);
 	if (ImGui::Begin("Particles", NULL, ImGuiWindowFlags_NoResize))
 	{
 		ImGui::Text("Toggle Computation Device");
@@ -476,6 +477,22 @@ void Application::renderUI(double dt)
 		if (ImGui::Button(btnLabel, ImVec2(40, 25))) {
 			m_pParticleEmitterHandler->toggleComputationDevice();
 		}
+
+		// Get currently selected
+		ParticleEmitter* pEmitter = m_pParticleEmitterHandler->getParticleEmitter(m_CurrentEmitterIdx);
+		glm::vec3 emitterPos = pEmitter->getPosition();
+		glm::vec3 emitterDirection = pEmitter->getDirection();
+		float emitterSpeed = pEmitter->getInitialSpeed();
+
+		if (ImGui::SliderFloat3("Position", glm::value_ptr(emitterPos), -10.0f, 10.0f)) {
+			pEmitter->setPosition(emitterPos);
+		} else if (ImGui::SliderFloat3("Direction", glm::value_ptr(emitterDirection), -1.0f, 1.0f)) {
+			pEmitter->setDirection(glm::normalize(emitterDirection));
+		} else if (ImGui::SliderFloat("Speed", &emitterSpeed, 0.0f, 20.0f)) {
+			pEmitter->setInitialSpeed(emitterSpeed);
+		}
+
+		ImGui::Text("Particles: %d", pEmitter->getParticleCount());
 	}
 	ImGui::End();
 
@@ -484,9 +501,6 @@ void Application::renderUI(double dt)
 
 void Application::render(double dt)
 {
-	if (m_pParticleEmitterHandler->gpuComputed()) {
-		int a = 0;
-	}
 	m_pRenderingHandler->beginFrame(m_Camera);
 
 	if (!m_EnableRayTracing) {

--- a/Project/src/Core/Application.h
+++ b/Project/src/Core/Application.h
@@ -65,6 +65,9 @@ private:
 	IParticleEmitterHandler* m_pParticleEmitterHandler;
 	ITexture2D* m_pParticleTexture;
 
+	// Resources for ImGui Particle window
+	size_t m_CurrentEmitterIdx;
+
 	bool m_IsRunning;
 	bool m_UpdateCamera;
 	bool m_EnableRayTracing;

--- a/Project/src/Core/ParticleEmitter.cpp
+++ b/Project/src/Core/ParticleEmitter.cpp
@@ -27,7 +27,7 @@ ParticleEmitter::ParticleEmitter(const ParticleEmitterInfo& emitterInfo)
     m_pAgesBuffer(nullptr),
     m_pEmitterBuffer(nullptr)
 {
-    buildCenteringQuaternion();
+    createCenteringQuaternion();
 }
 
 ParticleEmitter::~ParticleEmitter()
@@ -43,17 +43,7 @@ bool ParticleEmitter::initialize(IGraphicsContext* pGraphicsContext, const Camer
     m_pCamera = pCamera;
 
     size_t particleCount = m_ParticlesPerSecond * m_ParticleDuration;
-    m_ParticleStorage.positions.resize(particleCount);
-    m_ParticleStorage.velocities.resize(particleCount);
-    m_ParticleStorage.ages.resize(particleCount);
-
-    // Set the particle ages so that the first particle will respawn after the first update
-    float spawnRateReciprocal = 1.0f / m_ParticlesPerSecond;
-    std::vector<float>& ages = m_ParticleStorage.ages;
-
-    for (size_t i = 0; i < particleCount; i++) {
-        ages[i] = m_ParticleDuration - i * spawnRateReciprocal;
-    }
+    resizeParticleStorage(particleCount);
 
     return createBuffers(pGraphicsContext);
 }
@@ -93,7 +83,7 @@ void ParticleEmitter::createEmitterBuffer(EmitterBuffer& emitterBuffer)
 
 uint32_t ParticleEmitter::getParticleCount() const
 {
-    return std::min((uint32_t)(m_ParticlesPerSecond * m_ParticleDuration), (uint32_t)(m_ParticlesPerSecond * m_EmitterAge));
+    return uint32_t(m_ParticlesPerSecond * std::min(m_ParticleDuration, m_EmitterAge));
 }
 
 void ParticleEmitter::setPosition(const glm::vec3& position)
@@ -105,13 +95,31 @@ void ParticleEmitter::setPosition(const glm::vec3& position)
 void ParticleEmitter::setDirection(const glm::vec3& direction)
 {
     m_Direction = direction;
-    buildCenteringQuaternion();
+    createCenteringQuaternion();
     m_EmitterUpdated = true;
 }
 
 void ParticleEmitter::setInitialSpeed(float initialSpeed)
 {
     m_InitialSpeed = initialSpeed;
+    m_EmitterUpdated = true;
+}
+
+void ParticleEmitter::setParticlesPerSecond(float particlesPerSecond)
+{
+    size_t newParticleCount = m_ParticlesPerSecond * m_ParticleDuration;
+    resizeParticleStorage(newParticleCount);
+
+    m_ParticlesPerSecond = particlesPerSecond;
+    m_EmitterUpdated = true;
+}
+
+void ParticleEmitter::setParticleDuration(float particleDuration)
+{
+    size_t newParticleCount = m_ParticlesPerSecond * m_ParticleDuration;
+    resizeParticleStorage(newParticleCount);
+
+    m_ParticleDuration = particleDuration;
     m_EmitterUpdated = true;
 }
 
@@ -165,7 +173,7 @@ bool ParticleEmitter::createBuffers(IGraphicsContext* pGraphicsContext)
 void ParticleEmitter::spawnNewParticles()
 {
     size_t particleCount = m_ParticleStorage.positions.size();
-    size_t newParticleCount = size_t(m_EmitterAge * m_ParticlesPerSecond);
+    size_t newParticleCount = getParticleCount();
     size_t particlesToSpawn = newParticleCount - particleCount;
 
     if (particlesToSpawn == 0) {
@@ -193,7 +201,9 @@ void ParticleEmitter::moveParticles(float dt)
     std::vector<glm::vec4>& velocities = m_ParticleStorage.velocities;
     std::vector<float>& ages = m_ParticleStorage.ages;
 
-    for (size_t particleIdx = 0; particleIdx < positions.size(); particleIdx++) {
+    size_t particleCount = getParticleCount();
+
+    for (size_t particleIdx = 0; particleIdx < particleCount; particleIdx++) {
         positions[particleIdx] += velocities[particleIdx] * dt;
         velocities[particleIdx].y -= 9.82f * dt;
         ages[particleIdx] += dt;
@@ -206,6 +216,8 @@ void ParticleEmitter::respawnOldParticles()
     std::vector<glm::vec4>& velocities = m_ParticleStorage.velocities;
     std::vector<float>& ages = m_ParticleStorage.ages;
 
+    size_t particleCount = getParticleCount();
+
     /*
         TODO: Optimize respawning, dead pixels are grouped up, no need to iterate through the entire particle storage
         Three cases of particles grouping up: (d=dead, a=alive)
@@ -213,7 +225,7 @@ void ParticleEmitter::respawnOldParticles()
         (front) aaaaaaddd (back)
         (front) dddaaaaaa (back)
     */
-    for (size_t particleIdx = 0; particleIdx < m_ParticleStorage.positions.size(); particleIdx++) {
+    for (size_t particleIdx = 0; particleIdx < particleCount; particleIdx++) {
         float newParticleAge = ages[particleIdx] - m_ParticleDuration;
         if (newParticleAge < 0.0f) {
             continue;
@@ -256,10 +268,27 @@ void ParticleEmitter::createParticle(size_t particleIdx, float particleAge)
     m_ParticleStorage.ages[particleIdx] = particleAge;
 }
 
-void ParticleEmitter::buildCenteringQuaternion()
+void ParticleEmitter::createCenteringQuaternion()
 {
     glm::vec3 axis = glm::normalize(glm::cross(m_ZVec, m_Direction));
 
     float angle = glm::angle(m_ZVec, m_Direction);
     m_CenteringRotQuat = glm::angleAxis(angle, axis);
+}
+
+void ParticleEmitter::resizeParticleStorage(size_t newSize)
+{
+    size_t oldSize = m_ParticleStorage.positions.size();
+
+    m_ParticleStorage.positions.resize(newSize);
+    m_ParticleStorage.velocities.resize(newSize);
+    m_ParticleStorage.ages.resize(newSize);
+
+    // Set the particle ages so that the first particle will respawn after the first update
+    float spawnRateReciprocal = 1.0f / m_ParticlesPerSecond;
+    std::vector<float>& ages = m_ParticleStorage.ages;
+
+    for (size_t i = oldSize; i < newSize; i++) {
+        ages[i] = m_ParticleDuration - i * spawnRateReciprocal;
+    }
 }

--- a/Project/src/Core/ParticleEmitter.cpp
+++ b/Project/src/Core/ParticleEmitter.cpp
@@ -27,11 +27,7 @@ ParticleEmitter::ParticleEmitter(const ParticleEmitterInfo& emitterInfo)
     m_pAgesBuffer(nullptr),
     m_pEmitterBuffer(nullptr)
 {
-    // Calculate rotation quaternion
-    glm::vec3 axis = glm::normalize(glm::cross(m_ZVec, m_Direction));
-
-    float angle = glm::angle(m_ZVec, m_Direction);
-    m_CenteringRotQuat = glm::angleAxis(angle, axis);
+    buildCenteringQuaternion();
 }
 
 ParticleEmitter::~ParticleEmitter()
@@ -98,6 +94,25 @@ void ParticleEmitter::createEmitterBuffer(EmitterBuffer& emitterBuffer)
 uint32_t ParticleEmitter::getParticleCount() const
 {
     return std::min((uint32_t)(m_ParticlesPerSecond * m_ParticleDuration), (uint32_t)(m_ParticlesPerSecond * m_EmitterAge));
+}
+
+void ParticleEmitter::setPosition(const glm::vec3& position)
+{
+    m_Position = position;
+    m_EmitterUpdated = true;
+}
+
+void ParticleEmitter::setDirection(const glm::vec3& direction)
+{
+    m_Direction = direction;
+    buildCenteringQuaternion();
+    m_EmitterUpdated = true;
+}
+
+void ParticleEmitter::setInitialSpeed(float initialSpeed)
+{
+    m_InitialSpeed = initialSpeed;
+    m_EmitterUpdated = true;
 }
 
 bool ParticleEmitter::createBuffers(IGraphicsContext* pGraphicsContext)
@@ -239,4 +254,12 @@ void ParticleEmitter::createParticle(size_t particleIdx, float particleAge)
     m_ParticleStorage.velocities[particleIdx] = glm::vec4(glm::vec3(0.0f, gt, 0.0f) + V0, 0.0f);
     m_ParticleStorage.positions[particleIdx] = glm::vec4(glm::vec3(0.0f, gt * particleAge * 0.5f, 0.0f) + V0 * particleAge + m_Position, 1.0f);
     m_ParticleStorage.ages[particleIdx] = particleAge;
+}
+
+void ParticleEmitter::buildCenteringQuaternion()
+{
+    glm::vec3 axis = glm::normalize(glm::cross(m_ZVec, m_Direction));
+
+    float angle = glm::angle(m_ZVec, m_Direction);
+    m_CenteringRotQuat = glm::angleAxis(angle, axis);
 }

--- a/Project/src/Core/ParticleEmitter.h
+++ b/Project/src/Core/ParticleEmitter.h
@@ -54,10 +54,14 @@ public:
     glm::vec3 getPosition() const { return m_Position; }
     glm::vec3 getDirection() const { return m_Direction; }
     float getInitialSpeed() const { return m_InitialSpeed; }
+    float getParticlesPerSecond() const { return m_ParticlesPerSecond; }
+    float getParticleDuration() const { return m_ParticleDuration; }
+
     void setPosition(const glm::vec3& position);
     void setDirection(const glm::vec3& direction);
     void setInitialSpeed(float initialSpeed);
     void setParticlesPerSecond(float particlesPerSecond);
+    void setParticleDuration(float particleDuration);
 
     IBuffer* getPositionsBuffer() { return m_pPositionsBuffer; }
     IBuffer* getVelocitiesBuffer() { return m_pVelocitiesBuffer; }
@@ -78,7 +82,8 @@ private:
     void createParticle(size_t particleIdx, float particleAge);
 
     // Calculate rotation quaternion for spawning new particles in the desired direction
-    void buildCenteringQuaternion();
+    void createCenteringQuaternion();
+    void resizeParticleStorage(size_t newSize);
 
 private:
     glm::vec3 m_Position, m_Direction;

--- a/Project/src/Core/ParticleEmitter.h
+++ b/Project/src/Core/ParticleEmitter.h
@@ -29,7 +29,6 @@ struct EmitterBuffer {
     glm::vec2 particleSize;
     float particleDuration, initialSpeed, spread;
 };
-    // This padding gets the buffer size up to 128 bytes
 
 struct ParticleStorage {
     std::vector<glm::vec4> positions, velocities;
@@ -49,8 +48,16 @@ public:
 
     const ParticleStorage& getParticleStorage() const { return m_ParticleStorage; }
     void createEmitterBuffer(EmitterBuffer& emitterBuffer);
-    // TODO: Change this to use the emitter's age to calculate the particle count. Using the size doesn't work if particles only exist on the GPU.
+
     uint32_t getParticleCount() const;
+
+    glm::vec3 getPosition() const { return m_Position; }
+    glm::vec3 getDirection() const { return m_Direction; }
+    float getInitialSpeed() const { return m_InitialSpeed; }
+    void setPosition(const glm::vec3& position);
+    void setDirection(const glm::vec3& direction);
+    void setInitialSpeed(float initialSpeed);
+    void setParticlesPerSecond(float particlesPerSecond);
 
     IBuffer* getPositionsBuffer() { return m_pPositionsBuffer; }
     IBuffer* getVelocitiesBuffer() { return m_pVelocitiesBuffer; }
@@ -69,6 +76,9 @@ private:
     void moveParticles(float dt);
     void respawnOldParticles();
     void createParticle(size_t particleIdx, float particleAge);
+
+    // Calculate rotation quaternion for spawning new particles in the desired direction
+    void buildCenteringQuaternion();
 
 private:
     glm::vec3 m_Position, m_Direction;

--- a/Project/src/Core/Transform.cpp
+++ b/Project/src/Core/Transform.cpp
@@ -1,0 +1,32 @@
+#include "Transform.h"
+
+#include "glm/gtx/vector_angle.hpp"
+
+float getYaw(const glm::vec3& vec)
+{
+    glm::vec3 sameY = glm::normalize(glm::vec3(vec.x, g_DefaultForward.y, vec.z));
+
+	return glm::orientedAngle(g_DefaultForward, sameY, g_DefaultUp);
+}
+
+float getPitch(const glm::vec3& vec)
+{
+    glm::vec3 projectedToYPlane = glm::normalize(glm::vec3(vec.x, g_DefaultForward.y, vec.z));
+    float angle = glm::angle(vec, projectedToYPlane);
+
+    return vec.y > 0.0f ? angle : -angle;
+}
+
+void applyYaw(glm::vec3& vec, float yaw)
+{
+    glm::quat rotationQuat = glm::angleAxis(yaw, g_DefaultUp);
+    vec = rotationQuat * vec;
+}
+
+void applyPitch(glm::vec3& vec, float pitch)
+{
+    glm::vec3 right = glm::normalize(glm::cross(vec, g_DefaultUp));
+    glm::quat rotationQuat = glm::angleAxis(pitch, right);
+
+    vec = rotationQuat * vec;
+}

--- a/Project/src/Core/Transform.h
+++ b/Project/src/Core/Transform.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "glm/glm.hpp"
+
+const glm::vec3 g_DefaultForward(0.0f, 0.0f, 1.0f);
+const glm::vec3 g_DefaultUp(0.0f, 1.0f, 0.0f);
+const glm::vec3 g_DefaultRight(glm::cross(g_DefaultForward, g_DefaultUp));
+
+float getYaw(const glm::vec3& vec);
+float getPitch(const glm::vec3& vec);
+
+void applyYaw(glm::vec3& vec, float yaw);
+void applyPitch(glm::vec3& vec, float pitch);
+
+


### PR DESCRIPTION
There's more to come, but right now it is possible to control a single emitter's parameters:
* Position
* Rotation
* Initial particle speed

To be implemented:
* Particles per second
* Particle duration

Changing these parameters will increase the total amount of particles kept alive by the emitter.

To change these new parameters, the compute pipeline should first be able to pick the optimal work group sizes and amount of work groups, given the amount of particles an emitter spawns.