### PR TITLE
Maximize compute work group size

### DIFF
--- a/Project/assets/shaders/particles/update_cs.glsl
+++ b/Project/assets/shaders/particles/update_cs.glsl
@@ -1,6 +1,6 @@
 #version 450
 
-layout (local_size_x=1,local_size_y=1) in;
+layout (local_size_x_id=1, local_size_y=1, local_size_z=1) in;
 
 #define TWO_PI 2.0 * 3.1415926535897932384626433832795
 
@@ -9,27 +9,27 @@ layout (push_constant) uniform Constants
 	float dt;
 } g_Time;
 
-layout(binding = 0) buffer Positions
+layout (binding = 0) buffer Positions
 {
 	vec4 positions[];
 } g_Positions;
 
-layout(binding = 1) buffer Velocities
+layout (binding = 1) buffer Velocities
 {
 	vec4 velocities[];
 } g_Velocities;
 
-layout(binding = 2) buffer Ages
+layout (binding = 2) buffer Ages
 {
 	float ages[];
 } g_Ages;
 
-layout(binding = 3) uniform EmitterProperties
+layout (binding = 3) uniform EmitterProperties
 {
 	mat4 centeringRotMatrix;
 	vec4 position, direction;
     vec2 particleSize;
-    float particleDuration, initialSpeed, spread;
+    float particleDuration, initialSpeed, spread, particleCount;
 } g_EmitterProperties;
 
 float rand1(float p, float minVal, float maxVal)
@@ -78,6 +78,10 @@ void createParticle(uint particleIdx, float particleAge)
 void main()
 {
     uint particleIdx = gl_GlobalInvocationID.x;
+    if (particleIdx >= g_EmitterProperties.particleCount) {
+        return;
+    }
+
 	float dt = g_Time.dt;
     float age = g_Ages.ages[particleIdx] + dt;
 

--- a/Project/assets/shaders/particles/vertex.glsl
+++ b/Project/assets/shaders/particles/vertex.glsl
@@ -29,7 +29,7 @@ layout (binding = 3) uniform EmitterProperties
 	mat4 centeringRotMatrix;
 	vec4 position, direction;
     vec2 particleSize; // Only this variable is used in this shader
-    float particleDuration, initialSpeed, spread;
+    float particleDuration, initialSpeed, spread, particleCount;
 } g_EmitterProperties;
 
 layout (binding = 4) buffer ParticlePositions

--- a/Project/src/Core/Application.cpp
+++ b/Project/src/Core/Application.cpp
@@ -114,7 +114,7 @@ void Application::init()
 	emitterInfo.particleSize = glm::vec2(0.2f, 0.2f);
 	emitterInfo.initialSpeed = 5.5f;
 	emitterInfo.particleDuration = 3.0f;
-	emitterInfo.particlesPerSecond = 15.0f;
+	emitterInfo.particlesPerSecond = 40.0f;
 	emitterInfo.spread = glm::quarter_pi<float>() / 1.3f;
 	emitterInfo.pTexture = m_pParticleTexture;
 	m_pParticleEmitterHandler->createEmitter(emitterInfo);

--- a/Project/src/Core/ParticleEmitter.h
+++ b/Project/src/Core/ParticleEmitter.h
@@ -27,7 +27,7 @@ struct EmitterBuffer {
     glm::mat4x4 centeringRotMatrix;
     glm::vec4 position, direction;
     glm::vec2 particleSize;
-    float particleDuration, initialSpeed, spread;
+    float particleDuration, initialSpeed, spread, particleCount;
 };
 
 struct ParticleStorage {
@@ -75,8 +75,7 @@ public:
 private:
     bool createBuffers(IGraphicsContext* pGraphicsContext);
 
-    // Spawns particles before the emitter has created its maximum amount of particles
-    void spawnNewParticles();
+    void ageEmitter(float dt);
     void moveParticles(float dt);
     void respawnOldParticles();
     void createParticle(size_t particleIdx, float particleAge);

--- a/Project/src/Vulkan/DeviceVK.cpp
+++ b/Project/src/Vulkan/DeviceVK.cpp
@@ -3,6 +3,7 @@
 #include "CopyHandlerVK.h"
 #include "CommandBufferVK.h"
 
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <set>
@@ -16,6 +17,7 @@ DeviceVK::DeviceVK() :
 	m_ComputeQueue(VK_NULL_HANDLE),
 	m_TransferQueue(VK_NULL_HANDLE),
 	m_PresentQueue(VK_NULL_HANDLE),
+	m_DeviceLimits({}),
 	m_RayTracingProperties({}),
 	m_pCopyHandler()
 {
@@ -114,6 +116,11 @@ bool DeviceVK::hasUniqueQueueFamilyIndices() const
 	return familyIndices.size() == 4;
 }
 
+void DeviceVK::getMaxComputeWorkGroupSize(uint32_t pWorkGroupSize[3])
+{
+	std::memcpy(pWorkGroupSize, m_DeviceLimits.maxComputeWorkGroupSize, sizeof(uint32_t) * 3);
+}
+
 bool DeviceVK::initPhysicalDevice(InstanceVK* pInstance)
 {
 	uint32_t deviceCount = 0;
@@ -146,6 +153,11 @@ bool DeviceVK::initPhysicalDevice(InstanceVK* pInstance)
 	m_PhysicalDevice = physicalDeviceCandidates.rbegin()->second;
 	setEnabledExtensions();
 	m_DeviceQueueFamilyIndices = findQueueFamilies(m_PhysicalDevice);
+
+	// Save device's limits
+	VkPhysicalDeviceProperties deviceProperties;
+	vkGetPhysicalDeviceProperties(m_PhysicalDevice, &deviceProperties);
+	m_DeviceLimits = deviceProperties.limits;
 
 	return true;
 }

--- a/Project/src/Vulkan/DeviceVK.h
+++ b/Project/src/Vulkan/DeviceVK.h
@@ -44,7 +44,7 @@ public:
 	//GETTERS
 	VkPhysicalDevice getPhysicalDevice() { return m_PhysicalDevice; };
 	VkDevice getDevice() { return m_Device; }
-	
+
 	VkQueue getGraphicsQueue() { return m_GraphicsQueue; }
 	VkQueue getComputeQueue() { return m_ComputeQueue; }
 	VkQueue getTransferQueue() { return m_TransferQueue; }
@@ -54,7 +54,9 @@ public:
 
 	const QueueFamilyIndices& getQueueFamilyIndices() const { return m_DeviceQueueFamilyIndices; }
 	bool hasUniqueQueueFamilyIndices() const;
-	
+
+	void getMaxComputeWorkGroupSize(uint32_t pWorkGroupSize[3]);
+
 	const VkPhysicalDeviceRayTracingPropertiesNV& getRayTracingProperties() const { return m_RayTracingProperties; }
 	bool supportsRayTracing() const { return m_ExtensionsStatus.at(VK_NV_RAY_TRACING_EXTENSION_NAME); }
 
@@ -68,7 +70,7 @@ private:
 	QueueFamilyIndices findQueueFamilies(VkPhysicalDevice physicalDevice);
 
 	void registerExtensionFunctions();
-	
+
 private:
 	static uint32_t getQueueFamilyIndex(VkQueueFlagBits queueFlags, const std::vector<VkQueueFamilyProperties>& queueFamilies);
 	
@@ -90,6 +92,8 @@ private:
 	std::vector<VkExtensionProperties> m_AvailabeExtensions;
 
 	CopyHandlerVK* m_pCopyHandler;
+
+	VkPhysicalDeviceLimits m_DeviceLimits;
 
 	//Extensions
 	VkPhysicalDeviceRayTracingPropertiesNV m_RayTracingProperties;

--- a/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.h
+++ b/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.h
@@ -67,5 +67,8 @@ private:
     PipelineLayoutVK* m_pPipelineLayout;
     PipelineVK* m_pPipeline;
 
+    // Work items per work group launched in a compute shader dispatch
+    uint32_t m_WorkGroupSize;
+
     uint32_t m_CurrentFrame;
 };

--- a/Project/src/Vulkan/ShaderVK.h
+++ b/Project/src/Vulkan/ShaderVK.h
@@ -22,7 +22,7 @@ public:
 	template <typename T> void setSpecializationConstant(uint32_t index, T data);
 	void setSpecializationConstant(uint32_t index, void* pData, uint32_t sizeInBytes);
 
-	const VkSpecializationInfo* getSpecializationInfo() const { return m_SpecializationInfo .dataSize > 0 ? &m_SpecializationInfo : nullptr; }
+	const VkSpecializationInfo* getSpecializationInfo() const { return m_SpecializationInfo.dataSize > 0 ? &m_SpecializationInfo : nullptr; }
 	VkShaderModule getShaderModule() const { return m_ShaderModule; }
 
 private:
@@ -35,7 +35,7 @@ private:
 	VkSpecializationInfo m_SpecializationInfo;
 	std::vector<VkSpecializationMapEntry> m_SpecializationEntries;
 	std::vector<uint8_t> m_SpecializationData;
-	
+
 };
 
 template<typename T>


### PR DESCRIPTION
Use a specialization constant to compile the particle compute shader with the largest work group size supported by the GPU.