### PR TITLE
Multiple emitters

### DIFF
--- a/Project/src/Common/IDescriptorSet.h
+++ b/Project/src/Common/IDescriptorSet.h
@@ -1,0 +1,4 @@
+#pragma once
+
+class IDescriptorSet
+{};

--- a/Project/src/Core/ParticleEmitter.cpp
+++ b/Project/src/Core/ParticleEmitter.cpp
@@ -22,6 +22,8 @@ ParticleEmitter::ParticleEmitter(const ParticleEmitterInfo& emitterInfo)
     m_RandEngine(std::random_device()()),
     m_ZRandomizer(std::cos(m_Spread), 1.0f),
     m_PhiRandomizer(0.0f, glm::two_pi<float>()),
+    m_pDescriptorSetCompute(nullptr),
+    m_pDescriptorSetRender(nullptr),
     m_pPositionsBuffer(nullptr),
     m_pVelocitiesBuffer(nullptr),
     m_pAgesBuffer(nullptr),

--- a/Project/src/Core/ParticleEmitter.h
+++ b/Project/src/Core/ParticleEmitter.h
@@ -64,8 +64,11 @@ public:
     void setParticlesPerSecond(float particlesPerSecond);
     void setParticleDuration(float particleDuration);
 
-    IDescriptorSet* getDescriptorSet() { return m_pDescriptorSet; }
-    void setDescriptorSet(IDescriptorSet* pDescriptorSet) { m_pDescriptorSet = pDescriptorSet; }
+    IDescriptorSet* getDescriptorSetCompute() { return m_pDescriptorSetCompute; }
+    IDescriptorSet* getDescriptorSetRender() { return m_pDescriptorSetRender; }
+    void setDescriptorSetCompute(IDescriptorSet* pDescriptorSet) { m_pDescriptorSetCompute = pDescriptorSet; }
+    void setDescriptorSetRender(IDescriptorSet* pDescriptorSet) { m_pDescriptorSetRender = pDescriptorSet; }
+
     IBuffer* getPositionsBuffer() { return m_pPositionsBuffer; }
     IBuffer* getVelocitiesBuffer() { return m_pVelocitiesBuffer; }
     IBuffer* getAgesBuffer() { return m_pAgesBuffer; }
@@ -107,8 +110,10 @@ private:
     // The amount of time since the emitter started emitting particles. Used for spawning particles.
     float m_EmitterAge;
 
+    IDescriptorSet* m_pDescriptorSetCompute;
+    IDescriptorSet* m_pDescriptorSetRender;
+
     // GPU-side particle data
-    IDescriptorSet* m_pDescriptorSet;
     IBuffer* m_pPositionsBuffer;
     IBuffer* m_pVelocitiesBuffer;
     IBuffer* m_pAgesBuffer;

--- a/Project/src/Core/ParticleEmitter.h
+++ b/Project/src/Core/ParticleEmitter.h
@@ -10,6 +10,7 @@
 
 class Camera;
 class IBuffer;
+class IDescriptorSet;
 class IGraphicsContext;
 class IMesh;
 class ITexture2D;
@@ -63,6 +64,8 @@ public:
     void setParticlesPerSecond(float particlesPerSecond);
     void setParticleDuration(float particleDuration);
 
+    IDescriptorSet* getDescriptorSet() { return m_pDescriptorSet; }
+    void setDescriptorSet(IDescriptorSet* pDescriptorSet) { m_pDescriptorSet = pDescriptorSet; }
     IBuffer* getPositionsBuffer() { return m_pPositionsBuffer; }
     IBuffer* getVelocitiesBuffer() { return m_pVelocitiesBuffer; }
     IBuffer* getAgesBuffer() { return m_pAgesBuffer; }
@@ -105,11 +108,10 @@ private:
     float m_EmitterAge;
 
     // GPU-side particle data
+    IDescriptorSet* m_pDescriptorSet;
     IBuffer* m_pPositionsBuffer;
     IBuffer* m_pVelocitiesBuffer;
     IBuffer* m_pAgesBuffer;
-
-    // Contains particle size
     IBuffer* m_pEmitterBuffer;
 
     const Camera* m_pCamera;

--- a/Project/src/Vulkan/DescriptorSetVK.h
+++ b/Project/src/Vulkan/DescriptorSetVK.h
@@ -1,11 +1,13 @@
 #pragma once
+
+#include "Common/IDescriptorSet.h"
 #include "VulkanCommon.h"
 #include "DescriptorCounts.h"
 
 class DescriptorPoolVK;
 class DeviceVK;
 
-class DescriptorSetVK
+class DescriptorSetVK : public IDescriptorSet
 {
 public:
     DescriptorSetVK();

--- a/Project/src/Vulkan/MeshRendererVK.cpp
+++ b/Project/src/Vulkan/MeshRendererVK.cpp
@@ -284,7 +284,7 @@ bool MeshRendererVK::createPipelineLayouts()
 	std::vector<VkPushConstantRange> pushConstantRanges = { pushConstantRange };
 
 	m_pPipelineLayout = DBG_NEW PipelineLayoutVK(m_pContext->getDevice());
-	
+
 	//TODO: Return bool
 	m_pPipelineLayout->init(descriptorSetLayouts, pushConstantRanges);
 

--- a/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.cpp
+++ b/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.cpp
@@ -260,7 +260,7 @@ void ParticleEmitterHandlerVK::initializeEmitter(ParticleEmitter* pEmitter)
 	pEmitterDescriptorSet->writeStorageBufferDescriptor(pAgesBuffer->getBuffer(), 2);
 	pEmitterDescriptorSet->writeUniformBufferDescriptor(pEmitterBuffer->getBuffer(), 3);
 
-	pEmitter->setDescriptorSet(pEmitterDescriptorSet);
+	pEmitter->setDescriptorSetCompute(pEmitterDescriptorSet);
 
 	GraphicsContextVK* pGraphicsContext = reinterpret_cast<GraphicsContextVK*>(m_pGraphicsContext);
 	DeviceVK* pDevice = pGraphicsContext->getDevice();
@@ -325,7 +325,7 @@ void ParticleEmitterHandlerVK::updateGPU(float dt)
 		}
 
 		// TODO: Use constant variables or define macros for binding indices
-		DescriptorSetVK* pDescriptorSet = reinterpret_cast<DescriptorSetVK*>(pEmitter->getDescriptorSet());
+		DescriptorSetVK* pDescriptorSet = reinterpret_cast<DescriptorSetVK*>(pEmitter->getDescriptorSetCompute());
 		m_ppCommandBuffers[m_CurrentFrame]->bindDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, m_pPipelineLayout, 0, 1, &pDescriptorSet, 0, nullptr);
 
 		uint32_t particleCount = pEmitter->getParticleCount();

--- a/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.h
+++ b/Project/src/Vulkan/Particles/ParticleEmitterHandlerVK.h
@@ -66,7 +66,6 @@ private:
 
     DescriptorPoolVK* m_pDescriptorPool;
     DescriptorSetLayoutVK* m_pDescriptorSetLayout;
-    DescriptorSetVK* m_ppDescriptorSets[MAX_FRAMES_IN_FLIGHT];
 
     PipelineLayoutVK* m_pPipelineLayout;
     PipelineVK* m_pPipeline;

--- a/Project/src/Vulkan/Particles/ParticleRendererVK.h
+++ b/Project/src/Vulkan/Particles/ParticleRendererVK.h
@@ -33,7 +33,6 @@ public:
 	virtual void beginFrame(const Camera& camera) override;
 	virtual void endFrame() override;
 
-	void submitParticles(ParticleEmitterHandlerVK* pEmitterHandler);
 	void submitParticles(ParticleEmitter* pEmitter);
 
 	void setViewport(float width, float height, float minDepth, float maxDepth, float topX, float topY);
@@ -43,7 +42,8 @@ private:
 	bool createPipelineLayout();
 	bool createPipeline();
 	bool createQuadMesh();
-	void writeBufferDescriptors();
+
+	bool bindDescriptorSet(ParticleEmitter* pEmitter);
 
 private:
 	GraphicsContextVK* m_pGraphicsContext;
@@ -54,7 +54,6 @@ private:
 
 	DescriptorSetLayoutVK* m_pDescriptorSetLayout;
 	DescriptorPoolVK* m_pDescriptorPool;
-	DescriptorSetVK* m_ppDescriptorSets[MAX_FRAMES_IN_FLIGHT];
 
 	PipelineLayoutVK* m_pPipelineLayout;
 	PipelineVK* m_pPipeline;


### PR DESCRIPTION
I discovered that multiple emitters existing at once was not possible due to incorrect usage of descriptor sets: you can't have one descriptor set per renderer and update it per object, instead you let each object hold a descriptor set and bind it when you render the object.