### PR TITLE
Don't depth test fullscreen quad

### DIFF
--- a/Project/assets/shaders/lightFragment.glsl
+++ b/Project/assets/shaders/lightFragment.glsl
@@ -58,9 +58,9 @@ float Distrubution(vec3 normal, vec3 halfVector, float roughness)
 {
 	float roughnessSqrd = roughness*roughness;
 	float alphaSqrd 	= roughnessSqrd *roughnessSqrd;
-	
+
 	float NdotH = max(dot(normal, halfVector), 0.0f);
-	
+
 	float denom = ((NdotH * NdotH) * (alphaSqrd - 1.0f)) + 1.0f;
 	return alphaSqrd / (PI * denom * denom);
 }
@@ -72,7 +72,7 @@ float GeometryGGX(float NdotV, float roughness)
 {
 	float r 		= roughness + 1.0f;
 	float k_Direct 	= (r*r) / 8.0f;
-	
+
 	return NdotV / ((NdotV * (1.0f - k_Direct)) + k_Direct);
 }
 
@@ -83,7 +83,7 @@ float Geometry(vec3 normal, vec3 viewDir, vec3 lightDirection, float roughness)
 {
 	float NdotV = max(dot(normal, viewDir), 0.0f);
 	float NdotL = max(dot(normal, lightDirection), 0.0f);
-	
+
 	return GeometryGGX(NdotV, roughness) * GeometryGGX(NdotL, roughness);
 }
 
@@ -102,62 +102,62 @@ void main()
 	vec4 sampledAlbedo 			= texture(u_Albedo, texCoord);
 	vec4 sampledNormal 			= texture(u_Normal, texCoord);
 	vec4 sampledWorldPosition 	= texture(u_WorldPosition, texCoord);
-	
+
 	vec3 albedo 		= sampledAlbedo.rgb;
 	vec3 normal 		= sampledNormal.xyz;
 	vec3 worldPosition 	= sampledWorldPosition.xyz;
-	
+
 	//Just skybox
 	if (length(normal) == 0)
 	{
 	    out_Color = ColorPost(albedo);
 		return;
 	}
-	
+
 	float ao 			= sampledAlbedo.a;
 	float metallic 		= sampledNormal.a;
 	float roughness 	= sampledWorldPosition.a;
-	
+
 	normal = normalize(normal);
-	
+
 	vec3 cameraPosition = g_PerFrame.Position.xyz;
 	vec3 viewDir 		= normalize(cameraPosition - worldPosition);
 	vec3 reflection 	= reflect(-viewDir, normal);
-	
+
 	vec3 f0 = vec3(0.04f);
 	f0 = mix(f0, albedo, metallic);
 
 	float metallicFactor = 1.0f - metallic;
-	
+
 	//Radiance from light
 	vec3 L0 = vec3(0.0f);
 	for (int i = 0; i < MAX_POINT_LIGHTS; i++)
 	{
 		vec3 lightPosition 	= u_Lights.lights[i].Position.xyz;
 		vec3 lightColor 	= u_Lights.lights[i].Color.rgb;
-		
+
 		vec3 lightDirection = (lightPosition - worldPosition);
 		float distance 		= length(lightDirection);
 		float attenuation 	= 1.0f / (distance * distance);
 
 		lightDirection 	= normalize(lightDirection);
 		vec3 halfVector = normalize(viewDir + lightDirection);
-		
+
 		vec3 radiance = lightColor * attenuation;
-		
-		vec3 f 		= Fresnel(f0, clamp(dot(halfVector, viewDir), 0.0f, 1.0f));	
+
+		vec3 f 		= Fresnel(f0, clamp(dot(halfVector, viewDir), 0.0f, 1.0f));
 		float ndf 	= Distrubution(normal, halfVector, roughness);
 		float g 	= Geometry(normal, viewDir, lightDirection, roughness);
-		
+
 		float denom 	= (4.0f * max(dot(normal, viewDir), 0.0f) * max(dot(normal, lightDirection), 0.0f)) + 0.0001f;
-		vec3 specular   = (ndf * g * f) / denom;	
-		
+		vec3 specular   = (ndf * g * f) / denom;
+
 		//Take 1.0f minus the incoming radiance to get the diffuse (Energy conservation)
 		vec3 diffuse = (vec3(1.0f) - f) * metallicFactor;
-		
+
 		L0 += ((diffuse * (albedo / PI)) + specular) * radiance * max(dot(normal, lightDirection), 0.0f);
 	}
-	
+
 	//Irradiance from surroundings
 	vec3 irradiance = texture(u_IrradianceMap, normal).rgb;
 	vec3 diffuse 	= irradiance * albedo;
@@ -165,12 +165,12 @@ void main()
 	vec3 kDiffuse 	= (vec3(1.0f) - f) * metallicFactor;
 
 	vec3 prefilteredColor 	= textureLod(u_EnvironmentMap, reflection, roughness * MAX_REFLECTION_MIPS).rgb;
-	
+
 	vec2 envBRDF 	= texture(u_BrdfLUT, vec2(max(dot(normal, viewDir), 0.0f), roughness)).rg;
 	vec3 specular	= prefilteredColor * (f * envBRDF.x + envBRDF.y);
 
 	vec3 ambient 	= ((kDiffuse * diffuse) + specular) * ao;
-	
+
 	vec3 finalColor = ambient + L0;
     out_Color = ColorPost(finalColor);
 }

--- a/Project/src/Vulkan/MeshRendererVK.cpp
+++ b/Project/src/Vulkan/MeshRendererVK.cpp
@@ -120,7 +120,7 @@ bool MeshRendererVK::init()
 	{
 		return false;
 	}
-	
+
 	if (!createBuffersAndTextures())
 	{
 		return false;
@@ -644,8 +644,8 @@ bool MeshRendererVK::createPipelines()
 	rasterizerState.lineWidth	= 1.0f;
 	m_pLightPipeline->setRasterizerState(rasterizerState);
 
-	depthStencilState.depthTestEnable	= VK_TRUE;
-	depthStencilState.depthWriteEnable	= VK_TRUE;
+	depthStencilState.depthTestEnable	= VK_FALSE;
+	depthStencilState.depthWriteEnable	= VK_FALSE;
 	depthStencilState.depthCompareOp	= VK_COMPARE_OP_LESS;
 	depthStencilState.stencilTestEnable = VK_FALSE;
 	m_pLightPipeline->setDepthStencilState(depthStencilState);

--- a/Project/src/Vulkan/Particles/ParticleRendererVK.cpp
+++ b/Project/src/Vulkan/Particles/ParticleRendererVK.cpp
@@ -269,7 +269,7 @@ bool ParticleRendererVK::createPipeline()
 	m_pPipeline->setRasterizerState(rasterizerState);
 
 	VkPipelineDepthStencilStateCreateInfo depthStencilState = {};
-	depthStencilState.depthTestEnable	= VK_FALSE;
+	depthStencilState.depthTestEnable	= VK_TRUE;
 	depthStencilState.depthWriteEnable	= VK_FALSE;
 	depthStencilState.depthCompareOp	= VK_COMPARE_OP_LESS;
 	depthStencilState.stencilTestEnable	= VK_FALSE;

--- a/Project/src/Vulkan/RenderingHandlerVK.cpp
+++ b/Project/src/Vulkan/RenderingHandlerVK.cpp
@@ -98,6 +98,11 @@ bool RenderingHandlerVK::initialize()
 		return false;
 	}
 
+	if (!createGBuffer())
+	{
+		return false;
+	}
+
 	if (!createBackBuffers())
 	{
 		return false;
@@ -114,11 +119,6 @@ bool RenderingHandlerVK::initialize()
 	}
 
 	if (!createBuffers())
-	{
-		return false;
-	}
-
-	if (!createGBuffer())
 	{
 		return false;
 	}
@@ -383,7 +383,7 @@ bool RenderingHandlerVK::createBackBuffers()
 	DeviceVK* pDevice = m_pGraphicsContext->getDevice();
 
 	VkExtent2D extent = pSwapChain->getExtent();
-	ImageViewVK* pDepthStencilView = pSwapChain->getDepthStencilView();
+	ImageViewVK* pDepthStencilView = m_pGBuffer->getDepthAttachment();
 	for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
 	{
 		m_ppBackbuffers[i] = DBG_NEW FrameBufferVK(pDevice);
@@ -464,11 +464,11 @@ bool RenderingHandlerVK::createRenderPasses()
 
 	description.format			= VK_FORMAT_D24_UNORM_S8_UINT;
 	description.samples			= VK_SAMPLE_COUNT_1_BIT;
-	description.loadOp			= VK_ATTACHMENT_LOAD_OP_CLEAR;
+	description.loadOp			= VK_ATTACHMENT_LOAD_OP_LOAD;
 	description.storeOp			= VK_ATTACHMENT_STORE_OP_STORE;
 	description.stencilLoadOp	= VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	description.stencilStoreOp	= VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	description.initialLayout	= VK_IMAGE_LAYOUT_UNDEFINED;
+	description.initialLayout	= VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	description.finalLayout		= VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	m_pBackBufferRenderPass->addAttachment(description);
 


### PR DESCRIPTION
The fullscreen quad used when applying light to the backbuffer was being written to the depth buffer, causing particles to constantly be culled by the depth test.

Also had to tweak renderpass settings, so the depth buffer was loaded for the light pass.