### PR TITLE
Split renderpasses

### DIFF
--- a/Project/src/Common/RenderingHandler.hpp
+++ b/Project/src/Common/RenderingHandler.hpp
@@ -27,13 +27,15 @@ public:
 
     virtual ITextureCube* generateTextureCube(ITexture2D* pPanorama, ETextureFormat format, uint32_t width, uint32_t miplevels) = 0;
 
-    virtual void beginFrame(const Camera& camera, const LightSetup& lightSetup) = 0;
-    virtual void endFrame() = 0;
+    virtual void beginGeometryPass(const Camera* pCamera, const LightSetup* pLightSetup) = 0;
+    virtual void endGeometryPass() = 0;
+
+    virtual void drawLightPass() = 0;
 
     virtual void submitMesh(IMesh* pMesh, const Material& material, const glm::mat4& transform) = 0;
 
     virtual void drawProfilerUI() = 0;
-    
+
     virtual void swapBuffers() = 0;
 
     virtual void setClearColor(float r, float g, float b) = 0;
@@ -48,7 +50,7 @@ public:
     virtual void setImguiRenderer(IImgui* pImGui) = 0;
 
     virtual void onWindowResize(uint32_t width, uint32_t height) = 0;
-    
+
     void setParticleEmitterHandler(ParticleEmitterHandler* pParticleEmitterHandler) { m_pParticleEmitterHandler = pParticleEmitterHandler; }
 
 protected:

--- a/Project/src/Core/Application.cpp
+++ b/Project/src/Core/Application.cpp
@@ -596,7 +596,7 @@ void Application::renderUI(double dt)
 
 void Application::render(double dt)
 {
-	m_pRenderingHandler->beginFrame(m_Camera, m_LightSetup);
+	m_pRenderingHandler->beginGeometryPass(&m_Camera, &m_LightSetup);
 
 	static glm::mat4 rotation = glm::mat4(1.0f);
 	rotation = glm::rotate(rotation, glm::radians(30.0f * float(dt)), glm::vec3(0.0f, 1.0f, 0.0f));
@@ -623,6 +623,10 @@ void Application::render(double dt)
 		}
 	}
 
-	m_pRenderingHandler->endFrame();
+	m_pRenderingHandler->endGeometryPass();
+
+	// TODO: Update particles here, as they will need the depth buffer from the geometry pass to simulate collisions
+
+	m_pRenderingHandler->drawLightPass();
 	m_pRenderingHandler->swapBuffers();
 }

--- a/Project/src/Vulkan/Particles/ParticleRendererVK.h
+++ b/Project/src/Vulkan/Particles/ParticleRendererVK.h
@@ -33,7 +33,7 @@ public:
 
 	virtual void beginFrame(const Camera& camera, const LightSetup& lightSetup) override;
 	virtual void endFrame() override;
-	
+
 	virtual void setViewport(float width, float height, float minDepth, float maxDepth, float topX, float topY) override;
 
 	void submitParticles(ParticleEmitter* pEmitter);

--- a/Project/src/Vulkan/RenderingHandlerVK.h
+++ b/Project/src/Vulkan/RenderingHandlerVK.h
@@ -39,8 +39,10 @@ public:
 
     virtual ITextureCube* generateTextureCube(ITexture2D* pPanorama, ETextureFormat format, uint32_t width, uint32_t miplevels) override;
 
-    virtual void beginFrame(const Camera& camera, const LightSetup& lightsetup) override;
-    virtual void endFrame() override;
+    virtual void beginGeometryPass(const Camera* pCamera, const LightSetup* pLightsetup) override;
+    virtual void endGeometryPass() override;
+
+    virtual void drawLightPass() override;
 
     virtual void swapBuffers() override;
 
@@ -81,7 +83,7 @@ private:
 
     void releaseBackBuffers();
 
-    void updateBuffers(const Camera& camera);
+    void updateBuffers();
 
     void submitParticles();
 
@@ -89,6 +91,9 @@ private:
     std::vector<SubmitedMesh> m_SubmitedMeshes;
 
     GraphicsContextVK* m_pGraphicsContext;
+    // Set at the beginning of each frame
+    const Camera* m_pFrameCamera;
+    const LightSetup* m_pFrameLightSetup;
 
     SkyboxRendererVK* m_pSkyboxRenderer;
     MeshRendererVK* m_pMeshRenderer;


### PR DESCRIPTION
TLDR: Check the diff in `Application.cpp`

In order to perform collision simulation for particles, the depth buffer needs to contain drawn geometry. This means that particles need to be updated after the geometry pass.

This division of the geometry pass and the light pass enables things to be performed in between the passes.